### PR TITLE
add transform method to Api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["hpx <hephex@fucina.io>"]
 license = "MIT"
 description = "abstraction for HTTP API clients"


### PR DESCRIPTION
`transform` allows wrapping an instance of `Api`
and update its query, headers, and body.

The original `Api` can be used as a prototype
to create similar requests.

#1 